### PR TITLE
Design

### DIFF
--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -3,13 +3,19 @@
       <v-list>
       <v-list-item v-for="(item, index) in items" :key="index">
         <v-card elevation="3" width="800" class="mb-5">
-          <v-row>
-            <v-col>
-              <v-card-title class="text-h5" v-text="item.name"></v-card-title>
-              <v-card-text v-text="item.text"></v-card-text>
+          <v-row
+            style="height: 300px;"
+            justify="center" align-content="center"
+          >
+            <v-col cols="7">
+              <v-card-title v-text="item.name" class="text-h4"></v-card-title>
+              <v-card-text v-text="item.text1" class=""></v-card-text>
+              <v-card-text v-text="item.text2" class=""></v-card-text>
+              <v-card-text v-text="item.text3" class=""></v-card-text>
+              <v-card-text v-text="item.text4" class=""></v-card-text>
             </v-col>
-            <v-col class="d-flex justify-end mr-5">
-              <v-img :src="item.imgSrc" width="100"></v-img>
+            <v-col cols="3" class="d-flex justify-center mr-5">
+              <v-img :src="item.imgSrc" max-width="180" max-height="180" aspect-ratio="4/4" ></v-img>
             </v-col>
           </v-row>
         </v-card>
@@ -27,21 +33,34 @@
     data: () => ({
       items: {
         item1: {
-          name: 'Be3',
-          text: 'Doshisha Univ B4',
+          name: "Basic Info",
+          text1: "所属：同志社大学M1",
+          text2: "研究テーマ：画像が喚起する感情の推定をするモデルの構築",
+          text3: "",
           imgSrc: require('@/assets/img/gura_icon.png')
         },
         item2: {
-          name: 'Skills',
-          text: 'Language: Python, JavaScript, C#, Java, Framework: Django, Flask, WPF, Infra: AWS(EC2, S3, DynamoDB, Amplify, etc...), Docker',
+          name: "Skills",
+          text1: "言語: Python(daily), JavaScript(sometimes), C#(product dev), Java(sometimes), Go(learning)",
+          text2: "フレームワーク: Django, Flask, WPF",
+          text3: "インフラ: AWS(EC2, S3, DynamoDB, Amplify, etc...), Docker, Linux",
+          text4: "語学：TOEIC855, 英検準1級",
           imgSrc: require('@/assets/img/vue_logo.png')
         },
         item3: {
-          name: 'Career',
-          text: 'hogehoge',
+          name: "Experience",
+          text1: "hogehoge",
+          text2: "Azure Kinectを用いたWPFアプリ開発, Puppeteerを用いた業務効率化プログラムの開発 at 株式会社タカヤコミュニケーションズ",
+          text3: "",
           imgSrc: require('@/assets/img/pc_logo.png')
         }
       }
     }),
   }
 </script>
+<style>
+.card-text{
+  padding-top: 0%;
+  padding-bottom: 0%;
+}
+</style>

--- a/src/components/About.vue
+++ b/src/components/About.vue
@@ -9,13 +9,13 @@
           >
             <v-col cols="7">
               <v-card-title v-text="item.name" class="text-h4"></v-card-title>
-              <v-card-text v-text="item.text1" class=""></v-card-text>
-              <v-card-text v-text="item.text2" class=""></v-card-text>
-              <v-card-text v-text="item.text3" class=""></v-card-text>
-              <v-card-text v-text="item.text4" class=""></v-card-text>
+              <v-card-text v-text="item.text1" class="pt-1 pb-1"></v-card-text>
+              <v-card-text v-text="item.text2" class="pt-1 pb-1"></v-card-text>
+              <v-card-text v-text="item.text3" class="pt-1 pb-1"></v-card-text>
+              <v-card-text v-text="item.text4" class="pt-1 pb-1"></v-card-text>
             </v-col>
-            <v-col cols="3" class="d-flex justify-center mr-5">
-              <v-img :src="item.imgSrc" max-width="180" max-height="180" aspect-ratio="4/4" ></v-img>
+            <v-col cols="3" class="d-flex justify-center mr-5" style="height: 300px">
+              <v-img :src="item.imgSrc" max-width="180" max-height="180" aspect-ratio="4/4" style="margin-top:30px"></v-img>
             </v-col>
           </v-row>
         </v-card>
@@ -34,9 +34,9 @@
       items: {
         item1: {
           name: "Basic Info",
-          text1: "所属：同志社大学M1",
+          text1: "所属：同志社大学M1（24卒）",
           text2: "研究テーマ：画像が喚起する感情の推定をするモデルの構築",
-          text3: "",
+          text3: "趣味：猫，洋服，銭湯，スマブラ",
           imgSrc: require('@/assets/img/gura_icon.png')
         },
         item2: {
@@ -59,8 +59,5 @@
   }
 </script>
 <style>
-.card-text{
-  padding-top: 0%;
-  padding-bottom: 0%;
-}
+
 </style>


### PR DESCRIPTION
Aboutページにおける各画像の位置や余白等を修正しました。

- 画像位置を概ね中央寄せ（諦め）
- 画像サイズを正方形に統一
- 各カード内コンテンツのpaddingを調整
- テキストと画像の配置比率（v-colのcols）を7:3に統一